### PR TITLE
Register background activities

### DIFF
--- a/auto-clicker.xcodeproj/project.pbxproj
+++ b/auto-clicker.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		B5F6A01627F3900E003CD730 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F6A01527F3900E003CD730 /* Color+Extensions.swift */; };
 		B5F6A01927F3970A003CD730 /* ThemeColour.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F6A01827F3970A003CD730 /* ThemeColour.swift */; };
 		B5F6A01B27F3A8A6003CD730 /* StatBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F6A01A27F3A8A6003CD730 /* StatBox.swift */; };
+		C4345BB52846056000365CF9 /* ProcessInfo+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4345BB42846056000365CF9 /* ProcessInfo+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -106,6 +107,7 @@
 		B5F6A01527F3900E003CD730 /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		B5F6A01827F3970A003CD730 /* ThemeColour.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColour.swift; sourceTree = "<group>"; };
 		B5F6A01A27F3A8A6003CD730 /* StatBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatBox.swift; sourceTree = "<group>"; };
+		C4345BB42846056000365CF9 /* ProcessInfo+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -332,6 +334,7 @@
 				B5F6A01527F3900E003CD730 /* Color+Extensions.swift */,
 				B510762C27F4BF0C00BB1CDA /* Defaults+Workaround.swift */,
 				B510763A2800DDFF00BB1CDA /* NSEvent+Extensions.swift */,
+				C4345BB42846056000365CF9 /* ProcessInfo+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -516,6 +519,7 @@
 				B5F5C60B28039AA40049B04D /* FormState.swift in Sources */,
 				B510760F27F4A25400BB1CDA /* WindowStateService.swift in Sources */,
 				B5E92B1C27F1BA5E00A7FC63 /* Theme.swift in Sources */,
+				C4345BB52846056000365CF9 /* ProcessInfo+Extensions.swift in Sources */,
 				B5E6395327CA62EB008B111A /* ThemedButtonStyle.swift in Sources */,
 				B510762127F4BB4900BB1CDA /* AppearanceSettingsTabView.swift in Sources */,
 			);

--- a/auto-clicker/Extensions/ProcessInfo+Extensions.swift
+++ b/auto-clicker/Extensions/ProcessInfo+Extensions.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Combine
+
+enum Activity: String {
+    case delayTimer
+    case autoClicking
+
+    var options: ProcessInfo.ActivityOptions {
+        .userInitiated
+    }
+
+    var reason: String {
+        rawValue
+    }
+}
+
+extension ProcessInfo {
+    func beginActivity(_ activity: Activity) -> Cancellable {
+        let token = beginActivity(options: activity.options, reason: activity.reason)
+        return AnyCancellable { self.endActivity(token) }
+    }
+}

--- a/auto-clicker/Observable Objects/AutoClickSimulator.swift
+++ b/auto-clicker/Observable Objects/AutoClickSimulator.swift
@@ -26,9 +26,12 @@ final class AutoClickSimulator: ObservableObject {
 
     private var timer: Timer?
     private var mouseLocation: NSPoint { NSEvent.mouseLocation }
+    private var activity: Cancellable?
 
     func start() {
         self.isAutoClicking = true
+
+        self.activity = ProcessInfo.processInfo.beginActivity(.autoClicking)
 
         self.duration = Defaults[.autoClickerState].pressIntervalDuration
         self.interval = Defaults[.autoClickerState].pressInterval
@@ -49,6 +52,9 @@ final class AutoClickSimulator: ObservableObject {
 
     func stop() {
         self.isAutoClicking = false
+
+        self.activity?.cancel()
+        self.activity = nil
 
         // Force zero, as the user could stop the timer early
         self.remainingInterations = 0

--- a/auto-clicker/Observable Objects/DelayTimer.swift
+++ b/auto-clicker/Observable Objects/DelayTimer.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Defaults
+import Combine
 
 final class DelayTimer: ObservableObject {
     private static let defaultStartButtonText: String = "Start"
@@ -17,6 +18,7 @@ final class DelayTimer: ObservableObject {
 
     private var onFinish: () -> Void = {}
     private var timer: Timer?
+    private var activity: Cancellable?
 
     func start(onFinish: @escaping () -> Void) {
         let delayInSeconds = Defaults[.autoClickerState].startDelay
@@ -26,6 +28,7 @@ final class DelayTimer: ObservableObject {
         if delayInSeconds > 0 {
             self.remainingDelaySeconds = delayInSeconds
             self.isCountingDown = true
+            self.activity = ProcessInfo.processInfo.beginActivity(.delayTimer)
 
             self.updateButtonText()
 
@@ -54,6 +57,9 @@ final class DelayTimer: ObservableObject {
         self.startButtonText = DelayTimer.defaultStartButtonText
 
         self.isCountingDown = false
+
+        self.activity?.cancel()
+        self.activity = nil
 
         self.onFinish()
 


### PR DESCRIPTION
# Contents

Registers a background activity with the system during the delay countdown and auto click phases of execution.

The activity is registered as `.userInitiated`, which prevents system throttling of the application.

When the app returns to its idle state the activity tokens are released, and the system is once again allowed to throttle the app to conserve resources.

# Background

When the app window is not visible to the user the system considers the app [eligible for app nap](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/AppNap.html).

App nap will, among other things, throttle the active timers of the app. This can cause automatic clicks to not occur with the expected frequency. 

The degree to which the app is throttled is determined by the OS, and is more notable on systems with lower performance characteristics. 

On a 2016 Intel MacBook Pro I observed a significant slowdown of a 1 CPS run after about a minute of the app being off screen, with clicks occurring about once every 3-5 seconds instead of every second.

# Testing

Manual testing only, since app nap is not easily testable.

The "Energy" tab of the Activity Monitor app will indicate whether the app is currently in app nap, or is currently preventing system sleep.

Obscuring the app's window and observing the properties displayed in Activity Monitor will confirm that the app no longer enters the app nap state during an active run.

