### PR TITLE
Fix: The window size is not persisted between application sessions

### DIFF
--- a/auto-clicker.xcodeproj/project.pbxproj
+++ b/auto-clicker.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		B53BDC54264BED95001F8E57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B53BDC53264BED95001F8E57 /* Assets.xcassets */; };
 		B53BDC57264BED95001F8E57 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B53BDC56264BED95001F8E57 /* Preview Assets.xcassets */; };
 		B53BDC60264BF3A8001F8E57 /* NumberField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BDC5F264BF3A8001F8E57 /* NumberField.swift */; };
+		B5B0B2AF2882EE6E00462F11 /* ACWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B0B2AE2882EE6E00462F11 /* ACWindow.swift */; };
 		B5B6B46328032D3200C779FD /* PermissionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B6B46228032D3200C779FD /* PermissionsView.swift */; };
 		B5B6B46528033A0F00C779FD /* PermissionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B6B46428033A0F00C779FD /* PermissionsService.swift */; };
 		B5BCE803287BF59900B739AD /* Colour.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BCE802287BF59900B739AD /* Colour.swift */; };
@@ -91,6 +92,7 @@
 		B53BDC58264BED95001F8E57 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B53BDC59264BED95001F8E57 /* auto_clicker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = auto_clicker.entitlements; sourceTree = "<group>"; };
 		B53BDC5F264BF3A8001F8E57 /* NumberField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberField.swift; sourceTree = "<group>"; };
+		B5B0B2AE2882EE6E00462F11 /* ACWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWindow.swift; sourceTree = "<group>"; };
 		B5B6B46228032D3200C779FD /* PermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsView.swift; sourceTree = "<group>"; };
 		B5B6B46428033A0F00C779FD /* PermissionsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsService.swift; sourceTree = "<group>"; };
 		B5BCE802287BF59900B739AD /* Colour.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colour.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 		B510761227F4A34500BB1CDA /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				B5B0B2AE2882EE6E00462F11 /* ACWindow.swift */,
 				B5B6B46228032D3200C779FD /* PermissionsView.swift */,
 				B5F6A00E27F37440003CD730 /* MainView.swift */,
 				B5E6395127CA62DE008B111A /* Styles */,
@@ -547,6 +550,7 @@
 				B5BCE809287C2F4D00B739AD /* SmallText.swift in Sources */,
 				B5E4213728057BA900C2CA2D /* LoggerService.swift in Sources */,
 				B5E92B0E27F1036B00A7FC63 /* DurationModal.swift in Sources */,
+				B5B0B2AF2882EE6E00462F11 /* ACWindow.swift in Sources */,
 				B5BCE803287BF59900B739AD /* Colour.swift in Sources */,
 				B5F5C60B28039AA40049B04D /* FormState.swift in Sources */,
 				B510760F27F4A25400BB1CDA /* WindowStateService.swift in Sources */,

--- a/auto-clicker/Build Assets/Info.plist
+++ b/auto-clicker/Build Assets/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>64689c7</string>
+	<string>cae2c8f</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/auto-clicker/Constants/Defaults.swift
+++ b/auto-clicker/Constants/Defaults.swift
@@ -10,8 +10,6 @@ import Cocoa
 import Defaults
 
 extension Defaults.Keys {
-    static let windowSize = Key<CGVector>("window_size", default: CGVector(dx: 550, dy: 430))
-
     static let windowShouldKeepOnTop = Key<Bool>("window_should_keep_on_top", default: false)
 
     static let appearanceSelectedTheme = Key<ThemeService>("appearance_selected_theme", default: ThemeService())

--- a/auto-clicker/Init/AutoClickerApp.swift
+++ b/auto-clicker/Init/AutoClickerApp.swift
@@ -13,9 +13,7 @@ import Defaults
 struct AutoClickerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
 
-    @Default(.appearanceSelectedTheme) private var activeTheme
-
-    @StateObject private var permissionsService = PermissionsService()
+    @Default(.windowSize) private var windowSize
 
     var body: some Scene {
         Settings {
@@ -24,20 +22,17 @@ struct AutoClickerApp: App {
         }
 
         WindowGroup {
-            ZStack {
-                self.activeTheme.backgroundColour.ignoresSafeArea()
-
-                if self.permissionsService.isTrusted {
-                    MainView()
-                } else {
-                    PermissionsView()
-                }
+            GeometryReader { geometry in
+                ACWindow()
+                    .onChange(of: geometry.size) { newSize in
+                        self.windowSize.dx = newSize.width
+                        print(self.windowSize)
+                    }
             }
-            .frame(minWidth: WindowStateService.width,
-//                   maxWidth: WindowStateService.width,
-                   minHeight: WindowStateService.height,
-                   maxHeight: WindowStateService.height)
-            .onAppear(perform: self.permissionsService.pollAccessibilityPrivileges)
+            .frame(minWidth: WindowStateService.minWidth,
+                   idealWidth: self.windowSize.dx,
+                   minHeight: WindowStateService.minHeight,
+                   maxHeight: WindowStateService.minHeight)
         }
         .windowStyle(.hiddenTitleBar)
         .commands {

--- a/auto-clicker/Init/AutoClickerApp.swift
+++ b/auto-clicker/Init/AutoClickerApp.swift
@@ -13,8 +13,6 @@ import Defaults
 struct AutoClickerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
 
-    @Default(.windowSize) private var windowSize
-
     var body: some Scene {
         Settings {
             SettingsView()
@@ -22,17 +20,11 @@ struct AutoClickerApp: App {
         }
 
         WindowGroup {
-            GeometryReader { geometry in
-                ACWindow()
-                    .onChange(of: geometry.size) { newSize in
-                        self.windowSize.dx = newSize.width
-                        print(self.windowSize)
-                    }
-            }
-            .frame(minWidth: WindowStateService.minWidth,
-                   idealWidth: self.windowSize.dx,
-                   minHeight: WindowStateService.minHeight,
-                   maxHeight: WindowStateService.minHeight)
+            ACWindow()
+                .frame(minWidth: WindowStateService.minWidth,
+                       maxWidth: WindowStateService.minWidth * WindowStateService.maxDimensionMultiplier,
+                       minHeight: WindowStateService.minHeight,
+                       maxHeight: WindowStateService.minHeight)
         }
         .windowStyle(.hiddenTitleBar)
         .commands {

--- a/auto-clicker/Services/WindowStateService.swift
+++ b/auto-clicker/Services/WindowStateService.swift
@@ -10,11 +10,11 @@ import Cocoa
 import Defaults
 
 struct WindowStateService {
-    static let width: CGFloat = Defaults.Keys.windowSize.defaultValue.dx
-    static let height: CGFloat = Defaults.Keys.windowSize.defaultValue.dy
+    static let minWidth: CGFloat = 550
+    static let minHeight: CGFloat = 430
 
-    static let settingsWidth: CGFloat = 400
-    static let settingsHeight: CGFloat = 170
+    static let settingsMinWidth: CGFloat = 400
+    static let settingsMinHeight: CGFloat = 170
 
     static func toggleKeepWindowOnTop(_ keepOnTop: Bool) {
         // This is somewhat finiky... I originally used NSApplication.shared.mainWindow as it contained the primary window
@@ -35,5 +35,9 @@ struct WindowStateService {
 
     static func refreshKeepWindowOnTop() {
         self.toggleKeepWindowOnTop(Defaults[.windowShouldKeepOnTop])
+    }
+
+    static func shouldExitOnClose() -> Bool {
+        Defaults[.appShouldQuitOnClose]
     }
 }

--- a/auto-clicker/Services/WindowStateService.swift
+++ b/auto-clicker/Services/WindowStateService.swift
@@ -13,6 +13,8 @@ struct WindowStateService {
     static let minWidth: CGFloat = 550
     static let minHeight: CGFloat = 430
 
+    static let maxDimensionMultiplier: CGFloat = 1.3
+
     static let settingsMinWidth: CGFloat = 400
     static let settingsMinHeight: CGFloat = 170
 

--- a/auto-clicker/Views/Main/ACWindow.swift
+++ b/auto-clicker/Views/Main/ACWindow.swift
@@ -1,0 +1,28 @@
+//
+//  ACWindow.swift
+//  auto-clicker
+//
+//  Created by Ben Tindall on 16/07/2022.
+//
+
+import SwiftUI
+import Defaults
+
+struct ACWindow: View {
+    @Default(.appearanceSelectedTheme) private var activeTheme
+
+    @StateObject private var permissionsService = PermissionsService()
+
+    var body: some View {
+        ZStack {
+            self.activeTheme.backgroundColour.ignoresSafeArea()
+
+            if self.permissionsService.isTrusted {
+                MainView()
+            } else {
+                PermissionsView()
+            }
+        }
+        .onAppear(perform: self.permissionsService.pollAccessibilityPrivileges)
+    }
+}

--- a/auto-clicker/Views/Settings/SettingsView.swift
+++ b/auto-clicker/Views/Settings/SettingsView.swift
@@ -33,7 +33,7 @@ struct SettingsView: View {
                     Label("settings_appearance", systemImage: "paintpalette")
                 }
         }
-        .frame(width: WindowStateService.settingsWidth, height: WindowStateService.settingsHeight)
+        .frame(width: WindowStateService.settingsMinWidth, height: WindowStateService.settingsMinHeight)
         .padding()
         // Would love to theme the tab bar, but I can only find information on iOS and UITabBar
         // with NSTabView not having that much information on how to do this...


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Issue with the window size not persisting between states, the initial implementation was half baked anyway as there was never an event hook to update the value. So I did patch that and then attempt to restore the window state on load the SwiftUI way but there doesn't appear to be native functionality to allow this yet. So for now, just removed it and set up some wider limitations on the window bounds to allow for new languages not to be cut off.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #44 

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Language support fixes as other languages may trail off the window bounds.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
