### PR TITLE
feat: Notification options for when auto clicker starts and/or finishes

### DIFF
--- a/auto-clicker.xcodeproj/project.pbxproj
+++ b/auto-clicker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4C5D699D2A4ECDF800E72CEE /* NotificationsSettingsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5D699C2A4ECDF800E72CEE /* NotificationsSettingsTabView.swift */; };
+		4C5D699F2A4EED3500E72CEE /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5D699E2A4EED3500E72CEE /* NotificationService.swift */; };
 		B50022CA2875F5BF00610474 /* HelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50022C92875F5BF00610474 /* HelpCommands.swift */; };
 		B510760927F4A21500BB1CDA /* DateStrings in Frameworks */ = {isa = PBXBuildFile; productRef = B510760827F4A21500BB1CDA /* DateStrings */; };
 		B510760C27F4A23300BB1CDA /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = B510760B27F4A23300BB1CDA /* KeyboardShortcuts */; };
@@ -73,6 +75,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4C5D699C2A4ECDF800E72CEE /* NotificationsSettingsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsTabView.swift; sourceTree = "<group>"; };
+		4C5D699E2A4EED3500E72CEE /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		B50022C92875F5BF00610474 /* HelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpCommands.swift; sourceTree = "<group>"; };
 		B510760E27F4A25400BB1CDA /* WindowStateService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowStateService.swift; sourceTree = "<group>"; };
 		B510761027F4A33D00BB1CDA /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -169,6 +173,7 @@
 				B5B6B46428033A0F00C779FD /* PermissionsService.swift */,
 				B5E4213628057BA900C2CA2D /* LoggerService.swift */,
 				B5BF093F2883230D008092D9 /* MenuBarService.swift */,
+				4C5D699E2A4EED3500E72CEE /* NotificationService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -203,6 +208,7 @@
 				B510762227F4BB5F00BB1CDA /* KeyboardShortcutsSettingsTabView.swift */,
 				B510762427F4BB7B00BB1CDA /* WindowSettingsTabView.swift */,
 				B510762027F4BB4900BB1CDA /* AppearanceSettingsTabView.swift */,
+				4C5D699C2A4ECDF800E72CEE /* NotificationsSettingsTabView.swift */,
 			);
 			path = Tabs;
 			sourceTree = "<group>";
@@ -569,6 +575,7 @@
 				B5E92B0227F0D0D500A7FC63 /* ActionStageLine.swift in Sources */,
 				B5E92B1827F10A9E00A7FC63 /* UnderlinedStyleDivider.swift in Sources */,
 				B510763B2800DDFF00BB1CDA /* NSEvent+Extensions.swift in Sources */,
+				4C5D699F2A4EED3500E72CEE /* NotificationService.swift in Sources */,
 				B510763227FF7EC800BB1CDA /* InputAwareView.swift in Sources */,
 				B5B6B46328032D3200C779FD /* PermissionsView.swift in Sources */,
 				B510762327F4BB5F00BB1CDA /* KeyboardShortcutsSettingsTabView.swift in Sources */,
@@ -604,6 +611,7 @@
 				B53027FA264C2748002B8610 /* DelayTimer.swift in Sources */,
 				B5E6395627CA76CB008B111A /* Duration.swift in Sources */,
 				B53BDC60264BF3A8001F8E57 /* NumberField.swift in Sources */,
+				4C5D699D2A4ECDF800E72CEE /* NotificationsSettingsTabView.swift in Sources */,
 				B5BCE809287C2F4D00B739AD /* SmallText.swift in Sources */,
 				B5E4213728057BA900C2CA2D /* LoggerService.swift in Sources */,
 				B5E92B0E27F1036B00A7FC63 /* DurationModal.swift in Sources */,

--- a/auto-clicker/Constants/Defaults.swift
+++ b/auto-clicker/Constants/Defaults.swift
@@ -20,4 +20,7 @@ extension Defaults.Keys {
     static let appearanceSelectedTheme = Key<ThemeService>("appearance_selected_theme", default: ThemeService())
 
     static let autoClickerState = Key<FormState>("user_form_state", default: FormState())
+
+    static let notifyOnStart = Key<Bool>("notify_on_start", default: false)
+    static let notifyOnFinish = Key<Bool>("notify_on_finish", default: false)
 }

--- a/auto-clicker/Localisation/en-GB.lproj/Localizable.strings
+++ b/auto-clicker/Localisation/en-GB.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "settings_keyboard_shortcuts" = "Keyboard Shortcuts";
 "settings_window"             = "Window";
 "settings_appearance"         = "Appearance";
+"settings_notifications"      = "Notifications";
 
 "settings_general_app_should_quit_on_close_title" = "Lifecycle";
 "settings_general_app_should_quit_on_close"       = "Quit app on main window close";
@@ -54,6 +55,11 @@
 "settings_keyboard_shortcuts_start" = "Start auto clicker";
 "settings_keyboard_shortcuts_stop"  = "Stop auto clicker";
 "settings_keyboard_shortcuts_help"  = "Global shortcuts to start and stop the auto click functionality.";
+
+"settings_general_notify_title"     = "Notify when";
+"settings_general_notify_on_start"  = "Auto clicker starts";
+"settings_general_notify_on_finish" = "Auto clicker finishes";
+"settings_general_notify_help"      = "Receive a macOS notification when the auto clicker starts and/or finishes.";
 
 "settings_window_stay_ontop_title" = "Visibility";
 "settings_window_stay_ontop"       = "Always keep the main window on top";

--- a/auto-clicker/Observable Objects/AutoClickSimulator.swift
+++ b/auto-clicker/Observable Objects/AutoClickSimulator.swift
@@ -9,6 +9,7 @@ import Foundation
 import Combine
 import SwiftUI
 import Defaults
+import UserNotifications
 
 final class AutoClickSimulator: ObservableObject {
     static var shared: AutoClickSimulator = .init()
@@ -59,6 +60,14 @@ final class AutoClickSimulator: ObservableObject {
                                           selector: #selector(self.tick),
                                           userInfo: nil,
                                           repeats: true)
+
+        if Defaults[.notifyOnStart] {
+            NotificationService.scheduleNotification(title: "Started", date: self.nextClickAt)
+        }
+        if Defaults[.notifyOnFinish] {
+            NotificationService.scheduleNotification(title: "Finished", date: self.finalClickAt)
+        }
+
     }
 
     func stop() {

--- a/auto-clicker/Services/LoggerService.swift
+++ b/auto-clicker/Services/LoggerService.swift
@@ -24,6 +24,12 @@ final class LoggerService {
         ])
     }
 
+    static func notificationState(enabled: Bool, callingFile: String = #fileID, callingFunction: String = #function) {
+        LoggerService.log(file: callingFile, function: callingFunction, [
+            "Notification permissions \(enabled ? "" : "not ")granted"
+        ])
+    }
+
     static func permissionTrustedState(callingFile: String = #fileID, callingFunction: String = #function) {
         LoggerService.log(file: callingFile, function: callingFunction, [
             "Is trusted: \(AXIsProcessTrusted())"

--- a/auto-clicker/Services/NotificationService.swift
+++ b/auto-clicker/Services/NotificationService.swift
@@ -1,0 +1,28 @@
+//
+//  NotificationService.swift
+//  auto-clicker
+//
+//  Created by Anonymous-Alt-0 on 30/06/2023.
+//
+
+import Foundation
+import UserNotifications
+
+final class NotificationService: ObservableObject {
+    
+    static func scheduleNotification(title: String, body: String? = nil, date: Date) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        if body != nil { content.body = body! }
+        content.sound = UNNotificationSound.default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: date.timeIntervalSinceNow.rounded(),
+                                                        repeats: false)
+
+        let request = UNNotificationRequest(identifier: UUID().uuidString,
+                                            content: content,
+                                            trigger: trigger)
+
+        UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/auto-clicker/Services/PermissionsService.swift
+++ b/auto-clicker/Services/PermissionsService.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import UserNotifications
 
 // I had a lot of problems getting all this setup so that the Accessibility permissions were clear and prompted to the user.
 // macOS and Xcode have some 'interesting' quirks that impeade the development of this. Mainly that Xcode by default will run
@@ -41,5 +42,12 @@ final class PermissionsService: ObservableObject {
         let enabled = AXIsProcessTrustedWithOptions(options)
 
         LoggerService.permissionState(enabled: enabled)
+    }
+
+    static func acquireNotificationPermissions() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
+        { enabled, _ in
+            LoggerService.notificationState(enabled: enabled)
+        }
     }
 }

--- a/auto-clicker/Views/Settings/SettingsView.swift
+++ b/auto-clicker/Views/Settings/SettingsView.swift
@@ -55,6 +55,14 @@ struct SettingsView: View {
                 .onAppear {
                     self.changeFrameHeight(200)
                 }
+
+            NotificationsSettingsTabView()
+                .tabItem {
+                    Label("settings_notifications", systemImage: "bell")
+                }
+                .onAppear {
+                    self.changeFrameHeight(130)
+                }
         }
         .frame(width: WindowStateService.settingsMinWidth, height: self.frameHeight)
         .padding()

--- a/auto-clicker/Views/Settings/Tabs/NotificationsSettingsTabView.swift
+++ b/auto-clicker/Views/Settings/Tabs/NotificationsSettingsTabView.swift
@@ -1,0 +1,51 @@
+//
+//  NotificationsSettingsTabView.swift
+//  auto-clicker
+//
+//  Created by Anonymous-Alt-0 on 30/06/2023.
+//
+
+import Foundation
+import SwiftUI
+import Defaults
+import UserNotifications
+
+struct NotificationsSettingsTabView: View {
+    var body: some View {
+        SettingsTabView {
+            SettingsTabItemView(
+                title: "settings_general_notify_title"
+            ) {
+                Defaults.Toggle(
+                    " " + String(format: NSLocalizedString("settings_general_notify_on_start", comment: "Notify on auto clicker start toggle")),
+                    key: .notifyOnStart
+                )
+                .onChange { isOn in
+                    if isOn {
+                        PermissionsService.acquireNotificationPermissions()
+                    }
+                }
+            }
+
+            SettingsTabItemView(
+                help: "settings_general_notify_help"
+            ) {
+                Defaults.Toggle(
+                    " " + String(format: NSLocalizedString("settings_general_notify_on_finish", comment: "Notify on auto clicker finish toggle")),
+                    key: .notifyOnFinish
+                )
+                .onChange { isOn in
+                    if isOn {
+                        PermissionsService.acquireNotificationPermissions()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct NotificationsSettingsTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        NotificationsSettingsTabView()
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
An extra tab has been added to Settings for notifications. Two checkboxes to toggle whether you receive a macOS notification when the auto clicker starts and/or finishes running.
macOS will request notification permissions when a checkbox has been toggled for the first time.
A notification service has been added for future expansion of app notifications in mind (it's just a single static function atm).

# Related Issue
None

# Motivation and Context
Addresses the Issue 'Notifications #64' with tag 'Enhancement'.

# How Has This Been Tested?
Tested thoroughly on two different machines (intel and Apple Silicon).

# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
