### PR TITLE
fix: fixed 'Finished' notification appearing after manually cancelling timer

### DIFF
--- a/auto-clicker/Observable Objects/AutoClickSimulator.swift
+++ b/auto-clicker/Observable Objects/AutoClickSimulator.swift
@@ -90,6 +90,8 @@ final class AutoClickSimulator: ObservableObject {
         if let timer = self.timer {
             timer.invalidate()
         }
+
+        NotificationService.removePendingNotifications()
     }
 
     @objc private func tick() {

--- a/auto-clicker/Services/NotificationService.swift
+++ b/auto-clicker/Services/NotificationService.swift
@@ -25,4 +25,8 @@ final class NotificationService: ObservableObject {
 
         UNUserNotificationCenter.current().add(request)
     }
+
+    static func removePendingNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
 }


### PR DESCRIPTION
# Description
'Finished' notification now no longer appears if the user cancels the timer early. Either within the app, in the menu bar, or with a shortcut.

# Related Issue
[Notifications #64](https://github.com/othyn/macos-auto-clicker/issues/64)

# Motivation and Context
Fixes is bug so that if the user cancels the timer, notifications are cleared.

# How Has This Been Tested?
Cancelled the timer in all possible ways, all of which function as expected. Both during the countdown phase, and while running. Also still works as before when not cancelling the timer.

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
