### PR TITLE
feat: added dynamic menu bar option

### DIFF
--- a/auto-clicker/Constants/Defaults.swift
+++ b/auto-clicker/Constants/Defaults.swift
@@ -15,6 +15,7 @@ extension Defaults.Keys {
     static let windowShouldKeepOnTop = Key<Bool>("window_should_keep_on_top", default: false)
 
     static let menuBarShowIcon = Key<Bool>("menu_bar_show_icon", default: true)
+    static let menuBarShowDynamicIcon = Key<Bool>("menu_bar_show_dynamic_icon", default: false)
     static let menuBarHideDock = Key<Bool>("menu_bar_hide_dock", default: false)
 
     static let appearanceSelectedTheme = Key<ThemeService>("appearance_selected_theme", default: ThemeService())

--- a/auto-clicker/Localisation/en-GB.lproj/Localizable.strings
+++ b/auto-clicker/Localisation/en-GB.lproj/Localizable.strings
@@ -48,6 +48,9 @@
 "settings_general_menu_bar_show_icon"       = "Show menu bar icon";
 "settings_general_menu_bar_show_icon_help"  = "Always show an icon in the macOS menu bar where the app and quick access functionality can be accessed.";
 
+"settings_general_menu_bar_show_dynamic_icon"      = "Show dynamic menu bar icon";
+"settings_general_menu_bar_show_dynamic_icon_help" = "The menu bar icon will update based on the state of the auto clicker.\nOrange = Counting down to start\nGreen = Auto clicker running";
+
 "settings_general_menu_bar_hide_dock"      = "Hide dock icon";
 "settings_general_menu_bar_hide_dock_help" = "Instead of the app running from the dock, the app will instead run from the menu bar.";
 

--- a/auto-clicker/Observable Objects/AutoClickSimulator.swift
+++ b/auto-clicker/Observable Objects/AutoClickSimulator.swift
@@ -43,6 +43,8 @@ final class AutoClickSimulator: ObservableObject {
             stopMenuItem.isEnabled = true
         }
 
+        MenuBarService.changeImageColor(newColor: .green)
+
         self.activity = ProcessInfo.processInfo.beginActivity(.autoClicking)
 
         self.duration = Defaults[.autoClickerState].pressIntervalDuration
@@ -80,6 +82,8 @@ final class AutoClickSimulator: ObservableObject {
         if let stopMenuItem = MenuBarService.stopMenuItem {
             stopMenuItem.isEnabled = false
         }
+
+        MenuBarService.changeImageColor(newColor: .white)
 
         self.activity?.cancel()
         self.activity = nil

--- a/auto-clicker/Services/MenuBarService.swift
+++ b/auto-clicker/Services/MenuBarService.swift
@@ -41,6 +41,8 @@ final class MenuBarService {
             statusBarButton.image = NSImage(systemSymbolName: "cursorarrow.click.badge.clock", accessibilityDescription: "auto clicker")
             statusBarButton.action = #selector(togglePopover(sender:))
             statusBarButton.target = self
+
+            self.changeImageColor(newColor: .white)
         }
 
 //        Styling just didn't really work, this would work well for a Menu Bar app, but not for just simple clickable Menu Items...
@@ -137,6 +139,14 @@ final class MenuBarService {
 
     static func refreshState() {
         self.toggle(Defaults[.menuBarShowIcon])
+    }
+
+    static func changeImageColor(newColor: NSColor) {
+        if Defaults[.menuBarShowDynamicIcon], #available(macOS 12.0, *),
+        let statusBarButton = self.statusBarItem!.button {
+            let config = NSImage.SymbolConfiguration(paletteColors: [.white, newColor])
+            statusBarButton.image = statusBarButton.image!.withSymbolConfiguration(config)
+        }
     }
 
     @objc static func togglePopover(sender: AnyObject) {

--- a/auto-clicker/Views/Main/MainView.swift
+++ b/auto-clicker/Views/Main/MainView.swift
@@ -40,6 +40,7 @@ struct MainView: View {
     func start() {
         if !self.hasStarted {
             self.delayTimer.start(onFinish: self.autoClickSimulator.start)
+            MenuBarService.changeImageColor(newColor: .orange)
         }
     }
 

--- a/auto-clicker/Views/Settings/SettingsView.swift
+++ b/auto-clicker/Views/Settings/SettingsView.swift
@@ -29,7 +29,7 @@ struct SettingsView: View {
                     Label("settings_general", systemImage: "gear")
                 }
                 .onAppear {
-                    self.changeFrameHeight(330)
+                    self.changeFrameHeight(390)
                 }
 
             KeyboardShortcutsSettingsTabView()

--- a/auto-clicker/Views/Settings/Tabs/GeneralSettingsTabView.swift
+++ b/auto-clicker/Views/Settings/Tabs/GeneralSettingsTabView.swift
@@ -61,6 +61,27 @@ struct GeneralSettingsTabView: View {
                 }
             }
 
+            if #available(macOS 12.0, *) {
+                SettingsTabItemView(
+                    help: "settings_general_menu_bar_show_dynamic_icon_help"
+                ) {
+                    HStack {
+                        Defaults.Toggle(
+                            " " + String(format: NSLocalizedString("settings_general_menu_bar_show_dynamic_icon", comment: "Dynamic icon in menu bar toggle")),
+                            key: .menuBarShowDynamicIcon
+                        )
+                        .disabled(!self.menuBarShowIcon)
+
+                        Image(systemName: "cursorarrow.click.badge.clock")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, .orange)
+                        Image(systemName: "cursorarrow.click.badge.clock")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, .green)
+                    }
+                }
+            }
+
             SettingsTabItemView(
                 help: "settings_general_menu_bar_hide_dock_help"
             ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Dynamic menu bar changes colour based on the state of the auto clicker. Option is defaulted to off.
Orange = Counting down to start
Green = Auto clicker running

Unfortunately, this is only available from macOS 12 and up. I hope this isn't a big problem since the minimum deployment is only macOS 11.

# Related Issue
[#65](https://github.com/othyn/macos-auto-clicker/issues/65)

# Motivation and Context
I wanted to be able to view the state of the auto clicker at a glance, without having to go the menu bar item and click it.

# How Has This Been Tested?
Tested as best as I can. **Not** been tested on MacOS 11, but I believe I put the correct restrictions in places.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
