### PR TITLE
fix: Prevent saving empty key values in input handling 

### DIFF
--- a/auto-clicker/Views/Main/Components/PressKeyListenerModal.swift
+++ b/auto-clicker/Views/Main/Components/PressKeyListenerModal.swift
@@ -35,7 +35,7 @@ struct PressKeyListenerModal: View {
             return
         }
 
-        if input.keyCode != kVK_Escape || (input.keyCode == kVK_Escape && self.escapeKeyStreak > 1) {
+        if (input.keyCode != kVK_Escape || (input.keyCode == kVK_Escape && self.escapeKeyStreak > 1)) && !input.readable.isEmpty {
             self.formState.pressInput = input
 
             self.escapeKeyStreak = 0


### PR DESCRIPTION
---

```
fix: Prevent saving empty key values in input handling
```

---

## Description:
This fix ensures that invalid or empty key values (e.g., `0`) are not saved in the input state, preventing the app from becoming unresponsive and the UI input field from becoming unclickable.

---

## Related Issue:
Fixes issue #83.

---

## Motivation:
This change resolves a bug where unsupported or empty key values caused the app’s UI to stop responding, preventing further changes to the key value. The app now validates key inputs before saving them.

---

## How Has This Been Tested?
- Valid and invalid key values were tested to ensure only valid keys are saved.
- UI functionality was verified to ensure input fields remain clickable after invalid key presses.
- Escape key behavior was also tested to ensure proper handling.

---

## Types of changes:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

---

## Checklist:
- [x] My code follows the project’s coding style.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---