### PR TITLE
fix: mouse Y-coordinate calculation for multi-monitor setups

### DIFF
--- a/auto-clicker/Observable Objects/AutoClickSimulator.swift
+++ b/auto-clicker/Observable Objects/AutoClickSimulator.swift
@@ -139,7 +139,7 @@ final class AutoClickSimulator: ObservableObject {
 
     private func generateMouseClickEvents(source: CGEventSource?) -> [CGEvent?] {
         let mouseX = self.mouseLocation.x
-        let mouseY = NSScreen.main!.frame.height - self.mouseLocation.y
+        let mouseY = NSHeight(NSScreen.screens[0].frame) - mouseLocation.y
 
         let clickingAtPoint = CGPoint(x: mouseX, y: mouseY)
 


### PR DESCRIPTION

---

<!--- Provide a general summary of your changes in the Title above -->
**Fix Mouse Y-Coordinate Calculation for Multi-Monitor Setups**

# Description
Updated the method for calculating the Y-coordinate of the mouse in multi-monitor setups. The previous approach did not account for different screen heights in a multi-monitor environment, causing incorrect Y-values. This change ensures that the Y-coordinate is properly adjusted based on the screen's resolution and position.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #84 & #77

# Motivation and Context
This change is required because the previous calculation was incorrect when multiple monitors with different resolutions are involved. It solves the problem of the mouse coordinates jumping to the wrong screen, leading to incorrect clicks or interactions.

# How Has This Been Tested?
I tested this change in a multi-monitor environment with different screen resolutions. The mouse correctly follows the Y-coordinate based on the active screen without jumping to the main screen. Manual tests were conducted, and the issue no longer occurs.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---