### PR TITLE
fix: prevent crash when menu bar icon is disabled

### DIFF
--- a/auto-clicker/Services/MenuBarService.swift
+++ b/auto-clicker/Services/MenuBarService.swift
@@ -158,9 +158,13 @@ final class MenuBarService {
      *  nothing is coming up.
      */
     static func resetImage() {
-        if let statusBarButton = self.statusBarItem!.button {
-            statusBarButton.image = NSImage(systemSymbolName: "cursorarrow.click.badge.clock", accessibilityDescription: "auto clicker")
+        guard let statusBarItem = self.statusBarItem,
+              let statusBarButton = statusBarItem.button else {
+            return
         }
+
+        statusBarButton.image = NSImage(systemSymbolName: "cursorarrow.click.badge.clock",
+                                        accessibilityDescription: "auto clicker")
     }
 
     static func changeImageColour(newColor: NSColor) {


### PR DESCRIPTION
---

**Title:**  
fix: prevent crash when menu bar icon is disabled

# Description  
Fixes crash caused by force unwrapping nil `statusBarItem` when the menu bar icon is disabled. Safely unwraps optionals to avoid the issue.

# Related Issue  
Issue #80: App crashes when menu bar icon is disabled.

# Motivation and Context  
This change prevents crashes when the menu bar icon is disabled by safely handling nil values.

# How Has This Been Tested?  
Tested with the menu bar icon disabled and verified the app no longer crashes. Also tested with the icon enabled to ensure no regressions.

# Types of changes  
- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change

# Checklist  
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
- [ ] I have updated the documentation accordingly.  

---